### PR TITLE
김지훈 1차 작업 PR (타이틀 화면, 다른 장면들 틀 제작)

### DIFF
--- a/OSS-2024-Game.vcxproj
+++ b/OSS-2024-Game.vcxproj
@@ -156,6 +156,9 @@
     <ClInclude Include="src\State.h" />
     <ClInclude Include="src\TitleState.h" />
   </ItemGroup>
+  <ItemGroup>
+    <Font Include="resources\font\Arial.ttf" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/OSS-2024-Game.vcxproj
+++ b/OSS-2024-Game.vcxproj
@@ -139,6 +139,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="src\CustomFunction.cpp" />
     <ClCompile Include="src\GameManager.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="src\InGameState.cpp" />
@@ -148,6 +149,7 @@
     <ClCompile Include="src\TitleState.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="src\CustomFunction.h" />
     <ClInclude Include="src\GameManager.h" />
     <ClInclude Include="src\header\stdafx.h" />
     <ClInclude Include="src\InGameState.h" />

--- a/OSS-2024-Game.vcxproj
+++ b/OSS-2024-Game.vcxproj
@@ -141,12 +141,20 @@
   <ItemGroup>
     <ClCompile Include="src\GameManager.cpp" />
     <ClCompile Include="main.cpp" />
+    <ClCompile Include="src\InGameState.cpp" />
+    <ClCompile Include="src\MapSelectState.cpp" />
+    <ClCompile Include="src\ResultState.cpp" />
     <ClCompile Include="src\State.cpp" />
+    <ClCompile Include="src\TitleState.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\GameManager.h" />
     <ClInclude Include="src\header\stdafx.h" />
+    <ClInclude Include="src\InGameState.h" />
+    <ClInclude Include="src\MapSelectState.h" />
+    <ClInclude Include="src\ResultState.h" />
     <ClInclude Include="src\State.h" />
+    <ClInclude Include="src\TitleState.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/OSS-2024-Game.vcxproj.filters
+++ b/OSS-2024-Game.vcxproj.filters
@@ -27,6 +27,18 @@
     <ClCompile Include="src\State.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>
+    <ClCompile Include="src\InGameState.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
+    <ClCompile Include="src\MapSelectState.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
+    <ClCompile Include="src\ResultState.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
+    <ClCompile Include="src\TitleState.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\GameManager.h">
@@ -36,6 +48,18 @@
       <Filter>헤더 파일</Filter>
     </ClInclude>
     <ClInclude Include="src\State.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="src\InGameState.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="src\MapSelectState.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="src\ResultState.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="src\TitleState.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
   </ItemGroup>

--- a/OSS-2024-Game.vcxproj.filters
+++ b/OSS-2024-Game.vcxproj.filters
@@ -39,6 +39,9 @@
     <ClCompile Include="src\TitleState.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>
+    <ClCompile Include="src\CustomFunction.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\GameManager.h">
@@ -60,6 +63,9 @@
       <Filter>헤더 파일</Filter>
     </ClInclude>
     <ClInclude Include="src\TitleState.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="src\CustomFunction.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
   </ItemGroup>

--- a/OSS-2024-Game.vcxproj.filters
+++ b/OSS-2024-Game.vcxproj.filters
@@ -63,4 +63,7 @@
       <Filter>헤더 파일</Filter>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <Font Include="resources\font\Arial.ttf" />
+  </ItemGroup>
 </Project>

--- a/src/CustomFunction.cpp
+++ b/src/CustomFunction.cpp
@@ -1,0 +1,29 @@
+#include "CustomFunction.h"
+
+// 사이즈를 받아 X축 혹은 y축 상 중앙 위치 반환
+sf::Vector2f CustomMath::GetCenterPos(float x, float y, float width, float height)
+{
+    if (x == CustomMath::CENTER)
+        x = 640 - width / 2;
+    
+    if (y == CustomMath::CENTER)
+        y = 360 - height / 2;
+    
+    return sf::Vector2f(x, y);
+}
+
+// 벡터 크기 구하기
+float CustomMath::GetLength(const sf::Vector2f& vector)
+{
+	return std::sqrt(vector.x * vector.x + vector.y * vector.y);
+}
+
+// 벡터 정규화 (방향 정보만)
+sf::Vector2f CustomMath::Normalize(const sf::Vector2f& vector) {	
+	float length = CustomMath::GetLength(vector);
+	
+	if (length != 0.0f)
+		return sf::Vector2f(vector.x / length, vector.y / length);
+	else 
+		return vector;
+}

--- a/src/CustomFunction.h
+++ b/src/CustomFunction.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <SFML/Window.hpp>
+#include <SFML/Graphics.hpp>
+#include <SFML/System.hpp>
+
+
+class CustomMath
+{
+public:
+    static const int CENTER = -1;
+
+    static sf::Vector2f GetCenterPos(float x = CENTER, float y = CENTER, float width = 0.f, float height = 0.f);
+    static float GetLength(const sf::Vector2f& vector);
+    static sf::Vector2f Normalize(const sf::Vector2f& vector);
+};

--- a/src/GameManager.cpp
+++ b/src/GameManager.cpp
@@ -1,117 +1,117 @@
 #include "GameManager.h"
 
-// ê²Œì„ ê´€ë¦¬ì ìƒì„±ì
+// °ÔÀÓ °ü¸®ÀÚ »ı¼ºÀÚ
 GameManager::GameManager() 
 {
-	// í™”ë©´ ë³€ìˆ˜ì™€ í˜„ì¬ Stateë¥¼ ì´ˆê¸°í™”í•¨
+	// È­¸é º¯¼ö¿Í ÇöÀç State¸¦ ÃÊ±âÈ­ÇÔ
 	this->InitWindow();
 	this->InitStates();
 }
 
-// ê²Œì„ ê´€ë¦¬ì ì†Œë©¸ì
+// °ÔÀÓ °ü¸®ÀÚ ¼Ò¸êÀÚ
 GameManager::~GameManager()
 {
-	// í˜„ì¬ í™”ë©´ í¬ì¸í„°ë¥¼ í• ë‹¹ í•´ì œí•¨
+	// ÇöÀç È­¸é Æ÷ÀÎÅÍ¸¦ ÇÒ´ç ÇØÁ¦ÇÔ
 	delete this->window;
 }
 
-// í™”ë©´ ë³€ìˆ˜ ì´ˆê¸°í™” í•¨ìˆ˜
+// È­¸é º¯¼ö ÃÊ±âÈ­ ÇÔ¼ö
 void GameManager::InitWindow() 
 {
-	// ê²Œì„ ì œëª©, ì°½ í¬ê¸°, ìµœëŒ€ í”„ë ˆì„, VSync ê´€ë¦¬ ë³€ìˆ˜
+	// °ÔÀÓ Á¦¸ñ, Ã¢ Å©±â, ÃÖ´ë ÇÁ·¹ÀÓ, VSync °ü¸® º¯¼ö
 	std::string title = "Brick Pong";
 	sf::VideoMode window_bounds(1280, 720);
 	unsigned int frame_rate_limit = 60;
 	bool vertical_sync_enabled = false;
 
-	// RenderWindowë¥¼ ë§Œë“¤ì–´ í™”ë©´ í¬ì¸í„°ì— í• ë‹¹í•´ì¤Œ
+	// RenderWindow¸¦ ¸¸µé¾î È­¸é Æ÷ÀÎÅÍ¿¡ ÇÒ´çÇØÁÜ
 	this->window = new sf::RenderWindow(window_bounds, title);
 	
-	// í”„ë ˆì„ ì œí•œê³¼ VSync ì†ì„±ì„ í˜„ì¬ í™”ë©´ì— ë™ê¸°í™”í•¨
+	// ÇÁ·¹ÀÓ Á¦ÇÑ°ú VSync ¼Ó¼ºÀ» ÇöÀç È­¸é¿¡ µ¿±âÈ­ÇÔ
 	this->window->setFramerateLimit(frame_rate_limit);
 	this->window->setVerticalSyncEnabled(vertical_sync_enabled);
 
-	// TODO: ì•„ì´ì½˜ ì„¤ì • ì¶”ê°€
+	// TODO: ¾ÆÀÌÄÜ ¼³Á¤ Ãß°¡
 }
 
-// State ì´ˆê¸°í™” í•¨ìˆ˜
+// State ÃÊ±âÈ­ ÇÔ¼ö
 void GameManager::InitStates()
 {
-	// State ë±ì— ìƒˆë¡œìš´ Stateë¥¼ ë„£ì–´ì¤Œ
+	// State µ¦¿¡ »õ·Î¿î State¸¦ ³Ö¾îÁÜ
 	this->states.push_front(new TitleState(this->window));
 }
 
-// í”„ë ˆì„ë§ˆë‹¤ íë¥¸ ì‹œê°(dt, deltaTime)ì„ ì—…ë°ì´íŠ¸í•´ì¤Œ
+// ÇÁ·¹ÀÓ¸¶´Ù Èå¸¥ ½Ã°¢(dt, deltaTime)À» ¾÷µ¥ÀÌÆ®ÇØÁÜ
 void GameManager::UpdateDt()
 {
 	this->dt = this->dt_clock.restart().asSeconds();
 }
 
-// SFML ì´ë²¤íŠ¸ë¥¼ ì²˜ë¦¬í•˜ê¸° ìœ„í•œ í•¨ìˆ˜
+// SFML ÀÌº¥Æ®¸¦ Ã³¸®ÇÏ±â À§ÇÑ ÇÔ¼ö
 void GameManager::UpdateSFMLEvents()
 {
-	// í˜„ì¬ ì°½ì—ì„œ ì´ë²¤íŠ¸ê°€ ìˆì„ ì‹œ ì‹¤í–‰
+	// ÇöÀç Ã¢¿¡¼­ ÀÌº¥Æ®°¡ ÀÖÀ» ½Ã ½ÇÇà
 	while (this->window->pollEvent(this->event))
 	{
-		// ì¢…ë£Œ ì´ë²¤íŠ¸ë¥¼ ë°›ìœ¼ë©´ í˜„ì¬ ì°½ ì¢…ë£Œ
+		// Á¾·á ÀÌº¥Æ®¸¦ ¹ŞÀ¸¸é ÇöÀç Ã¢ Á¾·á
 		if (this->event.type == sf::Event::Closed)
 			this->window->close();
 	}
 }
 
-// ë§¤ í”„ë ˆì„ë§ˆë‹¤ ì—¬ëŸ¬ ì •ë³´ë¥¼ ê³„ì‚°í•˜ê³  ê°±ì‹ í•˜ëŠ” í•¨ìˆ˜
+// ¸Å ÇÁ·¹ÀÓ¸¶´Ù ¿©·¯ Á¤º¸¸¦ °è»êÇÏ°í °»½ÅÇÏ´Â ÇÔ¼ö
 void GameManager::Update()
 {
-	// SFML ì´ë²¤íŠ¸ ì²˜ë¦¬
+	// SFML ÀÌº¥Æ® Ã³¸®
 	this->UpdateSFMLEvents();
 
-	// í˜„ì¬ State ë±ì— ë“¤ì–´ìˆëŠ” Stateê°€ ìˆë‹¤ë©´
+	// ÇöÀç State µ¦¿¡ µé¾îÀÖ´Â State°¡ ÀÖ´Ù¸é
 	if (!this->states.empty()) 
 	{
-		// í˜„ì¬ ì‹¤í–‰ë˜ëŠ” StateëŠ” ë± ê°€ì¥ ì•ì— ìˆëŠ” State ì›ì†Œ
-		// í•´ë‹¹ Stateì˜ ì •ë³´ë¥¼ í”„ë ˆì„ ë‹¨ìœ„ë¡œ ê°±ì‹ í•¨
+		// ÇöÀç ½ÇÇàµÇ´Â State´Â µ¦ °¡Àå ¾Õ¿¡ ÀÖ´Â State ¿ø¼Ò
+		// ÇØ´ç StateÀÇ Á¤º¸¸¦ ÇÁ·¹ÀÓ ´ÜÀ§·Î °»½ÅÇÔ
 		this->states.front()->Update(this->dt);
 
-		// ë§Œì•½ í˜„ì¬ ì‹¤í–‰ë˜ëŠ” Stateì—ì„œ ì¢…ë£Œ ìš”ì²­ì„ ë°›ì•˜ì„ ì‹œ
+		// ¸¸¾à ÇöÀç ½ÇÇàµÇ´Â State¿¡¼­ Á¾·á ¿äÃ»À» ¹Ş¾ÒÀ» ½Ã
 		if (this->states.front()->GetQuit())
 		{
-			// í•´ë‹¹ State ì¢…ë£Œë¥¼ ìœ„í•œ ì „ì²˜ë¦¬ ì‘ì—…ì„ í•´ì¤Œ
+			// ÇØ´ç State Á¾·á¸¦ À§ÇÑ ÀüÃ³¸® ÀÛ¾÷À» ÇØÁÜ
 			this->states.front()->EndState();
 
-			// í•´ë‹¹ Stateì˜ í¬ì¸í„°ë¥¼ í•´ì œí•˜ê³ , ë±ì—ì„œ ì œì™¸ì‹œí‚´
+			// ÇØ´ç StateÀÇ Æ÷ÀÎÅÍ¸¦ ÇØÁ¦ÇÏ°í, µ¦¿¡¼­ Á¦¿Ü½ÃÅ´
 			delete this->states.front();
 			this->states.pop_front();
 		}
 	}
 	else 
 	{
-		// ë±ì— ë‚¨ì€ Stateê°€ ì—†ë‹¤ë©´ í™”ë©´ ì¢…ë£Œ
+		// µ¦¿¡ ³²Àº State°¡ ¾ø´Ù¸é È­¸é Á¾·á
 		this->window->close();
 	}
 }
 
-// ë§¤ í”„ë ˆì„ë§ˆë‹¤ ê°±ì‹ ëœ ì •ë³´ë¥¼ ë‹¤ì‹œ í™”ë©´ì— ê·¸ë ¤ì£¼ëŠ” í•¨ìˆ˜
+// ¸Å ÇÁ·¹ÀÓ¸¶´Ù °»½ÅµÈ Á¤º¸¸¦ ´Ù½Ã È­¸é¿¡ ±×·ÁÁÖ´Â ÇÔ¼ö
 void GameManager::Render()
 {
-	// í˜„ì¬ ì°½ì— ê·¸ë ¤ì§„ ê²ƒë“¤ì„ ì‚­ì œí•¨
+	// ÇöÀç Ã¢¿¡ ±×·ÁÁø °ÍµéÀ» »èÁ¦ÇÔ
 	this->window->clear();
 
-	// í˜„ì¬ State ë±ì— ë“¤ì–´ìˆëŠ” Stateê°€ ìˆë‹¤ë©´
+	// ÇöÀç State µ¦¿¡ µé¾îÀÖ´Â State°¡ ÀÖ´Ù¸é
 	if (!this->states.empty())
-		// í˜„ì¬ ì‹¤í–‰ë˜ëŠ” Stateì˜ ì •ë³´ë¥¼ ì´ í™”ë©´ì— ê·¸ë ¤ì¤Œ
+		// ÇöÀç ½ÇÇàµÇ´Â StateÀÇ Á¤º¸¸¦ ÀÌ È­¸é¿¡ ±×·ÁÁÜ
 		this->states.front()->Render(this->window);
 
-	// ëª¨ë‘ ê·¸ë ¸ìœ¼ë©´ ê·¸ë¦° ì°½ì„ í‘œì‹œí•¨
+	// ¸ğµÎ ±×·ÈÀ¸¸é ±×¸° Ã¢À» Ç¥½ÃÇÔ
 	this->window->display();
 }
 
-// ê²Œì„ ê´€ë¦¬ì ì‹¤í–‰
+// °ÔÀÓ °ü¸®ÀÚ ½ÇÇà
 void GameManager::Run()
 {
-	// ê²Œì„ ì°½ì´ ì—´ë ¤ìˆëŠ”ë™ì•ˆ
+	// °ÔÀÓ Ã¢ÀÌ ¿­·ÁÀÖ´Âµ¿¾È
 	while (this->window->isOpen())
 	{
-		// ë§¤ í”„ë ˆì„ë§ˆë‹¤ dt ê°±ì‹ , ì—…ë°ì´íŠ¸, ê·¸ë¦¬ê¸°ë¥¼ ë°˜ë³µ í˜¸ì¶œí•¨
+		// ¸Å ÇÁ·¹ÀÓ¸¶´Ù dt °»½Å, ¾÷µ¥ÀÌÆ®, ±×¸®±â¸¦ ¹İº¹ È£ÃâÇÔ
 		this->UpdateDt();
 		this->Update();
 		this->Render();

--- a/src/GameManager.cpp
+++ b/src/GameManager.cpp
@@ -1,117 +1,117 @@
 #include "GameManager.h"
 
-// °ÔÀÓ °ü¸®ÀÚ »ı¼ºÀÚ
+// ê²Œì„ ê´€ë¦¬ì ìƒì„±ì
 GameManager::GameManager() 
 {
-	// È­¸é º¯¼ö¿Í ÇöÀç State¸¦ ÃÊ±âÈ­ÇÔ
+	// í™”ë©´ ë³€ìˆ˜ì™€ í˜„ì¬ Stateë¥¼ ì´ˆê¸°í™”í•¨
 	this->InitWindow();
 	this->InitStates();
 }
 
-// °ÔÀÓ °ü¸®ÀÚ ¼Ò¸êÀÚ
+// ê²Œì„ ê´€ë¦¬ì ì†Œë©¸ì
 GameManager::~GameManager()
 {
-	// ÇöÀç È­¸é Æ÷ÀÎÅÍ¸¦ ÇÒ´ç ÇØÁ¦ÇÔ
+	// í˜„ì¬ í™”ë©´ í¬ì¸í„°ë¥¼ í• ë‹¹ í•´ì œí•¨
 	delete this->window;
 }
 
-// È­¸é º¯¼ö ÃÊ±âÈ­ ÇÔ¼ö
+// í™”ë©´ ë³€ìˆ˜ ì´ˆê¸°í™” í•¨ìˆ˜
 void GameManager::InitWindow() 
 {
-	// °ÔÀÓ Á¦¸ñ, Ã¢ Å©±â, ÃÖ´ë ÇÁ·¹ÀÓ, VSync °ü¸® º¯¼ö
+	// ê²Œì„ ì œëª©, ì°½ í¬ê¸°, ìµœëŒ€ í”„ë ˆì„, VSync ê´€ë¦¬ ë³€ìˆ˜
 	std::string title = "Brick Pong";
 	sf::VideoMode window_bounds(1280, 720);
 	unsigned int frame_rate_limit = 60;
 	bool vertical_sync_enabled = false;
 
-	// RenderWindow¸¦ ¸¸µé¾î È­¸é Æ÷ÀÎÅÍ¿¡ ÇÒ´çÇØÁÜ
+	// RenderWindowë¥¼ ë§Œë“¤ì–´ í™”ë©´ í¬ì¸í„°ì— í• ë‹¹í•´ì¤Œ
 	this->window = new sf::RenderWindow(window_bounds, title);
 	
-	// ÇÁ·¹ÀÓ Á¦ÇÑ°ú VSync ¼Ó¼ºÀ» ÇöÀç È­¸é¿¡ µ¿±âÈ­ÇÔ
+	// í”„ë ˆì„ ì œí•œê³¼ VSync ì†ì„±ì„ í˜„ì¬ í™”ë©´ì— ë™ê¸°í™”í•¨
 	this->window->setFramerateLimit(frame_rate_limit);
 	this->window->setVerticalSyncEnabled(vertical_sync_enabled);
 
-	// TODO: ¾ÆÀÌÄÜ ¼³Á¤ Ãß°¡
+	// TODO: ì•„ì´ì½˜ ì„¤ì • ì¶”ê°€
 }
 
-// State ÃÊ±âÈ­ ÇÔ¼ö
+// State ì´ˆê¸°í™” í•¨ìˆ˜
 void GameManager::InitStates()
 {
-	// State µ¦¿¡ »õ·Î¿î State¸¦ ³Ö¾îÁÜ
-	this->states.push_front(new State(this->window));
+	// State ë±ì— ìƒˆë¡œìš´ Stateë¥¼ ë„£ì–´ì¤Œ
+	this->states.push_front(new TitleState(this->window));
 }
 
-// ÇÁ·¹ÀÓ¸¶´Ù Èå¸¥ ½Ã°¢(dt, deltaTime)À» ¾÷µ¥ÀÌÆ®ÇØÁÜ
+// í”„ë ˆì„ë§ˆë‹¤ íë¥¸ ì‹œê°(dt, deltaTime)ì„ ì—…ë°ì´íŠ¸í•´ì¤Œ
 void GameManager::UpdateDt()
 {
 	this->dt = this->dt_clock.restart().asSeconds();
 }
 
-// SFML ÀÌº¥Æ®¸¦ Ã³¸®ÇÏ±â À§ÇÑ ÇÔ¼ö
+// SFML ì´ë²¤íŠ¸ë¥¼ ì²˜ë¦¬í•˜ê¸° ìœ„í•œ í•¨ìˆ˜
 void GameManager::UpdateSFMLEvents()
 {
-	// ÇöÀç Ã¢¿¡¼­ ÀÌº¥Æ®°¡ ÀÖÀ» ½Ã ½ÇÇà
+	// í˜„ì¬ ì°½ì—ì„œ ì´ë²¤íŠ¸ê°€ ìˆì„ ì‹œ ì‹¤í–‰
 	while (this->window->pollEvent(this->event))
 	{
-		// Á¾·á ÀÌº¥Æ®¸¦ ¹ŞÀ¸¸é ÇöÀç Ã¢ Á¾·á
+		// ì¢…ë£Œ ì´ë²¤íŠ¸ë¥¼ ë°›ìœ¼ë©´ í˜„ì¬ ì°½ ì¢…ë£Œ
 		if (this->event.type == sf::Event::Closed)
 			this->window->close();
 	}
 }
 
-// ¸Å ÇÁ·¹ÀÓ¸¶´Ù ¿©·¯ Á¤º¸¸¦ °è»êÇÏ°í °»½ÅÇÏ´Â ÇÔ¼ö
+// ë§¤ í”„ë ˆì„ë§ˆë‹¤ ì—¬ëŸ¬ ì •ë³´ë¥¼ ê³„ì‚°í•˜ê³  ê°±ì‹ í•˜ëŠ” í•¨ìˆ˜
 void GameManager::Update()
 {
-	// SFML ÀÌº¥Æ® Ã³¸®
+	// SFML ì´ë²¤íŠ¸ ì²˜ë¦¬
 	this->UpdateSFMLEvents();
 
-	// ÇöÀç State µ¦¿¡ µé¾îÀÖ´Â State°¡ ÀÖ´Ù¸é
+	// í˜„ì¬ State ë±ì— ë“¤ì–´ìˆëŠ” Stateê°€ ìˆë‹¤ë©´
 	if (!this->states.empty()) 
 	{
-		// ÇöÀç ½ÇÇàµÇ´Â State´Â µ¦ °¡Àå ¾Õ¿¡ ÀÖ´Â State ¿ø¼Ò
-		// ÇØ´ç StateÀÇ Á¤º¸¸¦ ÇÁ·¹ÀÓ ´ÜÀ§·Î °»½ÅÇÔ
+		// í˜„ì¬ ì‹¤í–‰ë˜ëŠ” StateëŠ” ë± ê°€ì¥ ì•ì— ìˆëŠ” State ì›ì†Œ
+		// í•´ë‹¹ Stateì˜ ì •ë³´ë¥¼ í”„ë ˆì„ ë‹¨ìœ„ë¡œ ê°±ì‹ í•¨
 		this->states.front()->Update(this->dt);
 
-		// ¸¸¾à ÇöÀç ½ÇÇàµÇ´Â State¿¡¼­ Á¾·á ¿äÃ»À» ¹Ş¾ÒÀ» ½Ã
+		// ë§Œì•½ í˜„ì¬ ì‹¤í–‰ë˜ëŠ” Stateì—ì„œ ì¢…ë£Œ ìš”ì²­ì„ ë°›ì•˜ì„ ì‹œ
 		if (this->states.front()->GetQuit())
 		{
-			// ÇØ´ç State Á¾·á¸¦ À§ÇÑ ÀüÃ³¸® ÀÛ¾÷À» ÇØÁÜ
+			// í•´ë‹¹ State ì¢…ë£Œë¥¼ ìœ„í•œ ì „ì²˜ë¦¬ ì‘ì—…ì„ í•´ì¤Œ
 			this->states.front()->EndState();
 
-			// ÇØ´ç StateÀÇ Æ÷ÀÎÅÍ¸¦ ÇØÁ¦ÇÏ°í, µ¦¿¡¼­ Á¦¿Ü½ÃÅ´
+			// í•´ë‹¹ Stateì˜ í¬ì¸í„°ë¥¼ í•´ì œí•˜ê³ , ë±ì—ì„œ ì œì™¸ì‹œí‚´
 			delete this->states.front();
 			this->states.pop_front();
 		}
 	}
 	else 
 	{
-		// µ¦¿¡ ³²Àº State°¡ ¾ø´Ù¸é È­¸é Á¾·á
+		// ë±ì— ë‚¨ì€ Stateê°€ ì—†ë‹¤ë©´ í™”ë©´ ì¢…ë£Œ
 		this->window->close();
 	}
 }
 
-// ¸Å ÇÁ·¹ÀÓ¸¶´Ù °»½ÅµÈ Á¤º¸¸¦ ´Ù½Ã È­¸é¿¡ ±×·ÁÁÖ´Â ÇÔ¼ö
+// ë§¤ í”„ë ˆì„ë§ˆë‹¤ ê°±ì‹ ëœ ì •ë³´ë¥¼ ë‹¤ì‹œ í™”ë©´ì— ê·¸ë ¤ì£¼ëŠ” í•¨ìˆ˜
 void GameManager::Render()
 {
-	// ÇöÀç Ã¢¿¡ ±×·ÁÁø °ÍµéÀ» »èÁ¦ÇÔ
+	// í˜„ì¬ ì°½ì— ê·¸ë ¤ì§„ ê²ƒë“¤ì„ ì‚­ì œí•¨
 	this->window->clear();
 
-	// ÇöÀç State µ¦¿¡ µé¾îÀÖ´Â State°¡ ÀÖ´Ù¸é
+	// í˜„ì¬ State ë±ì— ë“¤ì–´ìˆëŠ” Stateê°€ ìˆë‹¤ë©´
 	if (!this->states.empty())
-		// ÇöÀç ½ÇÇàµÇ´Â StateÀÇ Á¤º¸¸¦ ÀÌ È­¸é¿¡ ±×·ÁÁÜ
+		// í˜„ì¬ ì‹¤í–‰ë˜ëŠ” Stateì˜ ì •ë³´ë¥¼ ì´ í™”ë©´ì— ê·¸ë ¤ì¤Œ
 		this->states.front()->Render(this->window);
 
-	// ¸ğµÎ ±×·ÈÀ¸¸é ±×¸° Ã¢À» Ç¥½ÃÇÔ
+	// ëª¨ë‘ ê·¸ë ¸ìœ¼ë©´ ê·¸ë¦° ì°½ì„ í‘œì‹œí•¨
 	this->window->display();
 }
 
-// °ÔÀÓ °ü¸®ÀÚ ½ÇÇà
+// ê²Œì„ ê´€ë¦¬ì ì‹¤í–‰
 void GameManager::Run()
 {
-	// °ÔÀÓ Ã¢ÀÌ ¿­·ÁÀÖ´Âµ¿¾È
+	// ê²Œì„ ì°½ì´ ì—´ë ¤ìˆëŠ”ë™ì•ˆ
 	while (this->window->isOpen())
 	{
-		// ¸Å ÇÁ·¹ÀÓ¸¶´Ù dt °»½Å, ¾÷µ¥ÀÌÆ®, ±×¸®±â¸¦ ¹İº¹ È£ÃâÇÔ
+		// ë§¤ í”„ë ˆì„ë§ˆë‹¤ dt ê°±ì‹ , ì—…ë°ì´íŠ¸, ê·¸ë¦¬ê¸°ë¥¼ ë°˜ë³µ í˜¸ì¶œí•¨
 		this->UpdateDt();
 		this->Update();
 		this->Render();

--- a/src/GameManager.h
+++ b/src/GameManager.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "header/stdafx.h"
 #include "State.h"
+#include "TitleState.h"
 
 class GameManager 
 {

--- a/src/InGameState.cpp
+++ b/src/InGameState.cpp
@@ -1,0 +1,26 @@
+#include "InGameState.h"
+
+InGameState::InGameState(sf::RenderWindow* window) : State(window) {
+    this->font = new sf::Font();
+    this->font->loadFromFile("./Resources/Arial.ttf");
+}
+
+InGameState::~InGameState() {
+    delete this->font;
+}
+
+void InGameState::EndState() {
+
+}
+
+void InGameState::UpdateInput(const float& dt) {
+
+}
+
+void InGameState::Update(const float& dt) {
+
+}
+
+void InGameState::Render(sf::RenderTarget* target) {
+
+}

--- a/src/InGameState.cpp
+++ b/src/InGameState.cpp
@@ -1,26 +1,32 @@
 #include "InGameState.h"
 
-InGameState::InGameState(sf::RenderWindow* window) : State(window) {
+InGameState::InGameState(sf::RenderWindow* window) : State(window) 
+{
     this->font = new sf::Font();
     this->font->loadFromFile("./Resources/Arial.ttf");
 }
 
-InGameState::~InGameState() {
+InGameState::~InGameState() 
+{
     delete this->font;
 }
 
-void InGameState::EndState() {
+void InGameState::EndState() 
+{
 
 }
 
-void InGameState::UpdateInput(const float& dt) {
+void InGameState::UpdateInput(const float& dt) 
+{
 
 }
 
-void InGameState::Update(const float& dt) {
+void InGameState::Update(const float& dt) 
+{
 
 }
 
-void InGameState::Render(sf::RenderTarget* target) {
+void InGameState::Render(sf::RenderTarget* target) 
+{
 
 }

--- a/src/InGameState.cpp
+++ b/src/InGameState.cpp
@@ -3,7 +3,7 @@
 InGameState::InGameState(sf::RenderWindow* window) : State(window) 
 {
     this->font = new sf::Font();
-    this->font->loadFromFile("./Resources/Arial.ttf");
+    this->font->loadFromFile("./resources/font/Arial.ttf");
 }
 
 InGameState::~InGameState() 

--- a/src/InGameState.h
+++ b/src/InGameState.h
@@ -7,16 +7,17 @@ private:
 
 public:
 	sf::Font* font;
-	sf::Texture bgTexture;
-	sf::Sprite bgSprite;
+	// 일단 필요하지 않을 것 같아 주석 처리
+	// sf::Texture bgTexture;
+	// sf::Sprite bgSprite;
 
 	InGameState(sf::RenderWindow* window);
 	virtual ~InGameState();
 
-	void endState();
-	void updateInput(const float& dt);
-	void update(const float& dt);
-	void render(sf::RenderTarget* target);
+	void EndState();
+	void UpdateInput(const float& dt);
+	void Update(const float& dt);
+	void Render(sf::RenderTarget* target);
 };
 
 

--- a/src/InGameState.h
+++ b/src/InGameState.h
@@ -1,0 +1,22 @@
+#pragma once
+#include "State.h"
+
+class InGameState : State
+{
+private:
+
+public:
+	sf::Font* font;
+	sf::Texture bgTexture;
+	sf::Sprite bgSprite;
+
+	InGameState(sf::RenderWindow* window);
+	virtual ~InGameState();
+
+	void endState();
+	void updateInput(const float& dt);
+	void update(const float& dt);
+	void render(sf::RenderTarget* target);
+};
+
+

--- a/src/InGameState.h
+++ b/src/InGameState.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "State.h"
 
-class InGameState : State
+class InGameState : public State
 {
 private:
 

--- a/src/MapSelectState.cpp
+++ b/src/MapSelectState.cpp
@@ -1,26 +1,32 @@
 #include "MapSelectState.h"
 
-MapSelectState::MapSelectState(sf::RenderWindow* window) : State(window) {
+MapSelectState::MapSelectState(sf::RenderWindow* window) : State(window) 
+{
     this->font = new sf::Font();
     this->font->loadFromFile("./Resources/Arial.ttf");
 }
 
-MapSelectState::~MapSelectState() {
+MapSelectState::~MapSelectState() 
+{
     delete this->font;
 }
 
-void MapSelectState::EndState() {
+void MapSelectState::EndState() 
+{
 
 }
 
-void MapSelectState::UpdateInput(const float& dt) {
+void MapSelectState::UpdateInput(const float& dt) 
+{
 
 }
 
-void MapSelectState::Update(const float& dt) {
+void MapSelectState::Update(const float& dt) 
+{
 
 }
 
-void MapSelectState::Render(sf::RenderTarget* target) {
+void MapSelectState::Render(sf::RenderTarget* target) 
+{
 
 }

--- a/src/MapSelectState.cpp
+++ b/src/MapSelectState.cpp
@@ -1,0 +1,26 @@
+#include "MapSelectState.h"
+
+MapSelectState::MapSelectState(sf::RenderWindow* window) : State(window) {
+    this->font = new sf::Font();
+    this->font->loadFromFile("./Resources/Arial.ttf");
+}
+
+MapSelectState::~MapSelectState() {
+    delete this->font;
+}
+
+void MapSelectState::EndState() {
+
+}
+
+void MapSelectState::UpdateInput(const float& dt) {
+
+}
+
+void MapSelectState::Update(const float& dt) {
+
+}
+
+void MapSelectState::Render(sf::RenderTarget* target) {
+
+}

--- a/src/MapSelectState.cpp
+++ b/src/MapSelectState.cpp
@@ -3,7 +3,7 @@
 MapSelectState::MapSelectState(sf::RenderWindow* window) : State(window) 
 {
     this->font = new sf::Font();
-    this->font->loadFromFile("./Resources/Arial.ttf");
+    this->font->loadFromFile("./resources/font/Arial.ttf");
 }
 
 MapSelectState::~MapSelectState() 

--- a/src/MapSelectState.h
+++ b/src/MapSelectState.h
@@ -1,0 +1,21 @@
+#pragma once
+#include "State.h"
+
+class MapSelectState : State
+{
+private:
+
+public:
+	sf::Font* font;
+	sf::Texture bgTexture;
+	sf::Sprite bgSprite;
+
+	MapSelectState(sf::RenderWindow* window);
+	virtual ~MapSelectState();
+
+	void endState();
+	void updateInput(const float& dt);
+	void update(const float& dt);
+	void render(sf::RenderTarget* target);
+};
+

--- a/src/MapSelectState.h
+++ b/src/MapSelectState.h
@@ -7,15 +7,16 @@ private:
 
 public:
 	sf::Font* font;
-	sf::Texture bgTexture;
-	sf::Sprite bgSprite;
+	// 일단 필요하지 않을 것 같아 주석 처리
+	// sf::Texture bgTexture;
+	// sf::Sprite bgSprite;
 
 	MapSelectState(sf::RenderWindow* window);
 	virtual ~MapSelectState();
 
-	void endState();
-	void updateInput(const float& dt);
-	void update(const float& dt);
-	void render(sf::RenderTarget* target);
+	void EndState();
+	void UpdateInput(const float& dt);
+	void Update(const float& dt);
+	void Render(sf::RenderTarget* target);
 };
 

--- a/src/MapSelectState.h
+++ b/src/MapSelectState.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "State.h"
 
-class MapSelectState : State
+class MapSelectState : public State
 {
 private:
 

--- a/src/ResultState.cpp
+++ b/src/ResultState.cpp
@@ -1,0 +1,26 @@
+#include "ResultState.h"
+
+ResultState::ResultState(sf::RenderWindow* window) : State(window) {
+    this->font = new sf::Font();
+    this->font->loadFromFile("./Resources/Arial.ttf");
+}
+
+ResultState::~ResultState() {
+    delete this->font;
+}
+
+void ResultState::EndState() {
+
+}
+
+void ResultState::UpdateInput(const float& dt) {
+
+}
+
+void ResultState::Update(const float& dt) {
+
+}
+
+void ResultState::Render(sf::RenderTarget* target) {
+
+}

--- a/src/ResultState.cpp
+++ b/src/ResultState.cpp
@@ -3,7 +3,7 @@
 ResultState::ResultState(sf::RenderWindow* window) : State(window) 
 {
     this->font = new sf::Font();
-    this->font->loadFromFile("./Resources/Arial.ttf");
+    this->font->loadFromFile("./resources/font/Arial.ttf");
 }
 
 ResultState::~ResultState() 

--- a/src/ResultState.cpp
+++ b/src/ResultState.cpp
@@ -1,26 +1,32 @@
 #include "ResultState.h"
 
-ResultState::ResultState(sf::RenderWindow* window) : State(window) {
+ResultState::ResultState(sf::RenderWindow* window) : State(window) 
+{
     this->font = new sf::Font();
     this->font->loadFromFile("./Resources/Arial.ttf");
 }
 
-ResultState::~ResultState() {
+ResultState::~ResultState() 
+{
     delete this->font;
 }
 
-void ResultState::EndState() {
+void ResultState::EndState() 
+{
 
 }
 
-void ResultState::UpdateInput(const float& dt) {
+void ResultState::UpdateInput(const float& dt) 
+{
 
 }
 
-void ResultState::Update(const float& dt) {
+void ResultState::Update(const float& dt) 
+{
 
 }
 
-void ResultState::Render(sf::RenderTarget* target) {
+void ResultState::Render(sf::RenderTarget* target) 
+{
 
 }

--- a/src/ResultState.h
+++ b/src/ResultState.h
@@ -7,15 +7,16 @@ private:
 
 public:
 	sf::Font* font;
-	sf::Texture bgTexture;
-	sf::Sprite bgSprite;
+	// 일단 필요하지 않을 것 같아 주석 처리
+	// sf::Texture bgTexture;
+	// sf::Sprite bgSprite;
 
 	ResultState(sf::RenderWindow* window);
 	virtual ~ResultState();
 
-	void endState();
-	void updateInput(const float& dt);
-	void update(const float& dt);
-	void render(sf::RenderTarget* target);
+	void EndState();
+	void UpdateInput(const float& dt);
+	void Update(const float& dt);
+	void Render(sf::RenderTarget* target);
 };
 

--- a/src/ResultState.h
+++ b/src/ResultState.h
@@ -1,0 +1,21 @@
+#pragma once
+#include "State.h"
+
+class ResultState : State
+{
+private:
+
+public:
+	sf::Font* font;
+	sf::Texture bgTexture;
+	sf::Sprite bgSprite;
+
+	ResultState(sf::RenderWindow* window);
+	virtual ~ResultState();
+
+	void endState();
+	void updateInput(const float& dt);
+	void update(const float& dt);
+	void render(sf::RenderTarget* target);
+};
+

--- a/src/ResultState.h
+++ b/src/ResultState.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "State.h"
 
-class ResultState : State
+class ResultState : public State
 {
 private:
 

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -6,23 +6,6 @@ State::State(sf::RenderWindow* window)
 	// 창 포인터 변수 및 나가기 플래그 변수 초기화
 	this->window = window;
 	this->quit = false;
-
-	// 임시 폰트 초기화
-	this->font = new sf::Font();
-	// 폰트 로드 실패 시 바로 종료
-	if (!this->font->loadFromFile("./resources/font/Arial.ttf"))
-	{
-		std::cout << "[!] Font Load Failed!" << std::endl;
-		this->quit = true;
-	}
-
-	// 임시 텍스트 초기화, 폰트 및 속성 설정
-	this->text = new sf::Text();
-	this->text->setFont(*this->font);
-	this->text->setCharacterSize(72);
-	this->text->setPosition(sf::Vector2f(360.f, 60.f));
-	this->text->setFillColor(sf::Color::White);
-	this->text->setString("Brick Pong Game");
 }
 
 // State 소멸자
@@ -38,7 +21,8 @@ const bool& State::GetQuit() const
 }
 
 void State::CheckForQuit() {
-	if (sf::Keyboard::isKeyPressed(sf::Keyboard::Escape)) 
+	// 만약 ESC키를 누른 상태라면 나가기를 요청하도록 변수 설정
+	if (sf::Keyboard::isKeyPressed(sf::Keyboard::Escape))
 	{
 		this->quit = true;
 	}
@@ -53,11 +37,7 @@ void State::EndState()
 // 입력을 받아 처리하는 함수
 void State::UpdateInput(const float& dt) 
 {
-	// 만약 ESC키를 누른 상태라면 나가기를 요청하도록 변수 설정
-	if (sf::Keyboard::isKeyPressed(sf::Keyboard::Escape))
-	{
-		this->quit = true;
-	}
+	
 }
 
 // State의 정보를 프레임 단위로 갱신하는 함수
@@ -75,8 +55,4 @@ void State::Render(sf::RenderTarget* target)
 	// 출력하려는 창이 null이라면 현재 창으로 설정
 	if (!target)
 		target = this->window;
-
-	// 출력하려는 창 위에 여러 텍스쳐 등을 화면에 그림
-	// 현재는 임시 텍스트를 화면에 그려줌
-	target->draw(*this->text);
 }

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -1,22 +1,22 @@
 #include "State.h"
 
-// State ìƒì„±ìž
+// State »ý¼ºÀÚ
 State::State(sf::RenderWindow* window) 
 {
-	// ì°½ í¬ì¸í„° ë³€ìˆ˜ ë° ë‚˜ê°€ê¸° í”Œëž˜ê·¸ ë³€ìˆ˜ ì´ˆê¸°í™”
+	// Ã¢ Æ÷ÀÎÅÍ º¯¼ö ¹× ³ª°¡±â ÇÃ·¡±× º¯¼ö ÃÊ±âÈ­
 	this->window = window;
 	this->quit = false;
 
-	// ìž„ì‹œ í°íŠ¸ ì´ˆê¸°í™”
+	// ÀÓ½Ã ÆùÆ® ÃÊ±âÈ­
 	this->font = new sf::Font();
-	// í°íŠ¸ ë¡œë“œ ì‹¤íŒ¨ ì‹œ ë°”ë¡œ ì¢…ë£Œ
+	// ÆùÆ® ·Îµå ½ÇÆÐ ½Ã ¹Ù·Î Á¾·á
 	if (!this->font->loadFromFile("./resources/font/Arial.ttf"))
 	{
 		std::cout << "[!] Font Load Failed!" << std::endl;
 		this->quit = true;
 	}
 
-	// ìž„ì‹œ í…ìŠ¤íŠ¸ ì´ˆê¸°í™”, í°íŠ¸ ë° ì†ì„± ì„¤ì •
+	// ÀÓ½Ã ÅØ½ºÆ® ÃÊ±âÈ­, ÆùÆ® ¹× ¼Ó¼º ¼³Á¤
 	this->text = new sf::Text();
 	this->text->setFont(*this->font);
 	this->text->setCharacterSize(72);
@@ -25,13 +25,13 @@ State::State(sf::RenderWindow* window)
 	this->text->setString("Brick Pong Game");
 }
 
-// State ì†Œë©¸ìž
+// State ¼Ò¸êÀÚ
 State::~State()
 {
 
 }
 
-// í˜„ìž¬ Stateì˜ ë‚˜ê°€ê¸° í”Œëž˜ê·¸ ë³€ìˆ˜ ìƒíƒœë¥¼ ë°˜í™˜í•˜ëŠ” í•¨ìˆ˜
+// ÇöÀç StateÀÇ ³ª°¡±â ÇÃ·¡±× º¯¼ö »óÅÂ¸¦ ¹ÝÈ¯ÇÏ´Â ÇÔ¼ö
 const bool& State::GetQuit() const 
 {
 	return this->quit;
@@ -44,39 +44,39 @@ void State::CheckForQuit() {
 	}
 }
 
-// State ì¢…ë£Œ ìš”ì²­ì„ ë°›ì•˜ì„ ì‹œ ì¢…ë£Œ ì „ ìž‘ì—…ì„ í•˜ëŠ” í•¨ìˆ˜
+// State Á¾·á ¿äÃ»À» ¹Þ¾ÒÀ» ½Ã Á¾·á Àü ÀÛ¾÷À» ÇÏ´Â ÇÔ¼ö
 void State::EndState()
 {
 
 }
 
-// ìž…ë ¥ì„ ë°›ì•„ ì²˜ë¦¬í•˜ëŠ” í•¨ìˆ˜
+// ÀÔ·ÂÀ» ¹Þ¾Æ Ã³¸®ÇÏ´Â ÇÔ¼ö
 void State::UpdateInput(const float& dt) 
 {
-	// ë§Œì•½ ESCí‚¤ë¥¼ ëˆ„ë¥¸ ìƒíƒœë¼ë©´ ë‚˜ê°€ê¸°ë¥¼ ìš”ì²­í•˜ë„ë¡ ë³€ìˆ˜ ì„¤ì •
+	// ¸¸¾à ESCÅ°¸¦ ´©¸¥ »óÅÂ¶ó¸é ³ª°¡±â¸¦ ¿äÃ»ÇÏµµ·Ï º¯¼ö ¼³Á¤
 	if (sf::Keyboard::isKeyPressed(sf::Keyboard::Escape))
 	{
 		this->quit = true;
 	}
 }
 
-// Stateì˜ ì •ë³´ë¥¼ í”„ë ˆìž„ ë‹¨ìœ„ë¡œ ê°±ì‹ í•˜ëŠ” í•¨ìˆ˜
+// StateÀÇ Á¤º¸¸¦ ÇÁ·¹ÀÓ ´ÜÀ§·Î °»½ÅÇÏ´Â ÇÔ¼ö
 void State::Update(const float& dt)
 {
-	// ì¼ë‹¨ í”„ë ˆìž„ë§ˆë‹¤ ìž…ë ¥ í™•ì¸ë§Œ í•´ì¤Œ
+	// ÀÏ´Ü ÇÁ·¹ÀÓ¸¶´Ù ÀÔ·Â È®ÀÎ¸¸ ÇØÁÜ
 	this->UpdateInput(dt);
 
-	// ê²Œìž„ì„ ë§Œë“¤ë©´ì„œ í”„ë ˆìž„ ë‹¨ìœ„ë¡œ ìˆ˜í–‰ë˜ëŠ” ì½”ë“œë“¤ì´ ì˜¬ ê²ƒ
+	// °ÔÀÓÀ» ¸¸µé¸é¼­ ÇÁ·¹ÀÓ ´ÜÀ§·Î ¼öÇàµÇ´Â ÄÚµåµéÀÌ ¿Ã °Í
 }
 
-// Stateì˜ ê°±ì‹ ëœ ì •ë³´ë¥¼ í™”ë©´ì— ê·¸ë ¤ì£¼ëŠ” í•¨ìˆ˜
+// StateÀÇ °»½ÅµÈ Á¤º¸¸¦ È­¸é¿¡ ±×·ÁÁÖ´Â ÇÔ¼ö
 void State::Render(sf::RenderTarget* target)
 {
-	// ì¶œë ¥í•˜ë ¤ëŠ” ì°½ì´ nullì´ë¼ë©´ í˜„ìž¬ ì°½ìœ¼ë¡œ ì„¤ì •
+	// Ãâ·ÂÇÏ·Á´Â Ã¢ÀÌ nullÀÌ¶ó¸é ÇöÀç Ã¢À¸·Î ¼³Á¤
 	if (!target)
 		target = this->window;
 
-	// ì¶œë ¥í•˜ë ¤ëŠ” ì°½ ìœ„ì— ì—¬ëŸ¬ í…ìŠ¤ì³ ë“±ì„ í™”ë©´ì— ê·¸ë¦¼
-	// í˜„ìž¬ëŠ” ìž„ì‹œ í…ìŠ¤íŠ¸ë¥¼ í™”ë©´ì— ê·¸ë ¤ì¤Œ
+	// Ãâ·ÂÇÏ·Á´Â Ã¢ À§¿¡ ¿©·¯ ÅØ½ºÃÄ µîÀ» È­¸é¿¡ ±×¸²
+	// ÇöÀç´Â ÀÓ½Ã ÅØ½ºÆ®¸¦ È­¸é¿¡ ±×·ÁÁÜ
 	target->draw(*this->text);
 }

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -1,22 +1,22 @@
 #include "State.h"
 
-// State »ý¼ºÀÚ
+// State ìƒì„±ìž
 State::State(sf::RenderWindow* window) 
 {
-	// Ã¢ Æ÷ÀÎÅÍ º¯¼ö ¹× ³ª°¡±â ÇÃ·¡±× º¯¼ö ÃÊ±âÈ­
+	// ì°½ í¬ì¸í„° ë³€ìˆ˜ ë° ë‚˜ê°€ê¸° í”Œëž˜ê·¸ ë³€ìˆ˜ ì´ˆê¸°í™”
 	this->window = window;
 	this->quit = false;
 
-	// ÀÓ½Ã ÆùÆ® ÃÊ±âÈ­
+	// ìž„ì‹œ í°íŠ¸ ì´ˆê¸°í™”
 	this->font = new sf::Font();
-	// ÆùÆ® ·Îµå ½ÇÆÐ ½Ã ¹Ù·Î Á¾·á
+	// í°íŠ¸ ë¡œë“œ ì‹¤íŒ¨ ì‹œ ë°”ë¡œ ì¢…ë£Œ
 	if (!this->font->loadFromFile("./resources/font/Arial.ttf"))
 	{
 		std::cout << "[!] Font Load Failed!" << std::endl;
 		this->quit = true;
 	}
 
-	// ÀÓ½Ã ÅØ½ºÆ® ÃÊ±âÈ­, ÆùÆ® ¹× ¼Ó¼º ¼³Á¤
+	// ìž„ì‹œ í…ìŠ¤íŠ¸ ì´ˆê¸°í™”, í°íŠ¸ ë° ì†ì„± ì„¤ì •
 	this->text = new sf::Text();
 	this->text->setFont(*this->font);
 	this->text->setCharacterSize(72);
@@ -25,51 +25,58 @@ State::State(sf::RenderWindow* window)
 	this->text->setString("Brick Pong Game");
 }
 
-// State ¼Ò¸êÀÚ
+// State ì†Œë©¸ìž
 State::~State()
 {
 
 }
 
-// ÇöÀç StateÀÇ ³ª°¡±â ÇÃ·¡±× º¯¼ö »óÅÂ¸¦ ¹ÝÈ¯ÇÏ´Â ÇÔ¼ö
+// í˜„ìž¬ Stateì˜ ë‚˜ê°€ê¸° í”Œëž˜ê·¸ ë³€ìˆ˜ ìƒíƒœë¥¼ ë°˜í™˜í•˜ëŠ” í•¨ìˆ˜
 const bool& State::GetQuit() const 
 {
 	return this->quit;
 }
 
-// State Á¾·á ¿äÃ»À» ¹Þ¾ÒÀ» ½Ã Á¾·á Àü ÀÛ¾÷À» ÇÏ´Â ÇÔ¼ö
+void State::CheckForQuit() {
+	if (sf::Keyboard::isKeyPressed(sf::Keyboard::Escape)) 
+	{
+		this->quit = true;
+	}
+}
+
+// State ì¢…ë£Œ ìš”ì²­ì„ ë°›ì•˜ì„ ì‹œ ì¢…ë£Œ ì „ ìž‘ì—…ì„ í•˜ëŠ” í•¨ìˆ˜
 void State::EndState()
 {
 
 }
 
-// ÀÔ·ÂÀ» ¹Þ¾Æ Ã³¸®ÇÏ´Â ÇÔ¼ö
+// ìž…ë ¥ì„ ë°›ì•„ ì²˜ë¦¬í•˜ëŠ” í•¨ìˆ˜
 void State::UpdateInput(const float& dt) 
 {
-	// ¸¸¾à ESCÅ°¸¦ ´©¸¥ »óÅÂ¶ó¸é ³ª°¡±â¸¦ ¿äÃ»ÇÏµµ·Ï º¯¼ö ¼³Á¤
+	// ë§Œì•½ ESCí‚¤ë¥¼ ëˆ„ë¥¸ ìƒíƒœë¼ë©´ ë‚˜ê°€ê¸°ë¥¼ ìš”ì²­í•˜ë„ë¡ ë³€ìˆ˜ ì„¤ì •
 	if (sf::Keyboard::isKeyPressed(sf::Keyboard::Escape))
 	{
 		this->quit = true;
 	}
 }
 
-// StateÀÇ Á¤º¸¸¦ ÇÁ·¹ÀÓ ´ÜÀ§·Î °»½ÅÇÏ´Â ÇÔ¼ö
+// Stateì˜ ì •ë³´ë¥¼ í”„ë ˆìž„ ë‹¨ìœ„ë¡œ ê°±ì‹ í•˜ëŠ” í•¨ìˆ˜
 void State::Update(const float& dt)
 {
-	// ÀÏ´Ü ÇÁ·¹ÀÓ¸¶´Ù ÀÔ·Â È®ÀÎ¸¸ ÇØÁÜ
+	// ì¼ë‹¨ í”„ë ˆìž„ë§ˆë‹¤ ìž…ë ¥ í™•ì¸ë§Œ í•´ì¤Œ
 	this->UpdateInput(dt);
 
-	// °ÔÀÓÀ» ¸¸µé¸é¼­ ÇÁ·¹ÀÓ ´ÜÀ§·Î ¼öÇàµÇ´Â ÄÚµåµéÀÌ ¿Ã °Í
+	// ê²Œìž„ì„ ë§Œë“¤ë©´ì„œ í”„ë ˆìž„ ë‹¨ìœ„ë¡œ ìˆ˜í–‰ë˜ëŠ” ì½”ë“œë“¤ì´ ì˜¬ ê²ƒ
 }
 
-// StateÀÇ °»½ÅµÈ Á¤º¸¸¦ È­¸é¿¡ ±×·ÁÁÖ´Â ÇÔ¼ö
+// Stateì˜ ê°±ì‹ ëœ ì •ë³´ë¥¼ í™”ë©´ì— ê·¸ë ¤ì£¼ëŠ” í•¨ìˆ˜
 void State::Render(sf::RenderTarget* target)
 {
-	// Ãâ·ÂÇÏ·Á´Â Ã¢ÀÌ nullÀÌ¶ó¸é ÇöÀç Ã¢À¸·Î ¼³Á¤
+	// ì¶œë ¥í•˜ë ¤ëŠ” ì°½ì´ nullì´ë¼ë©´ í˜„ìž¬ ì°½ìœ¼ë¡œ ì„¤ì •
 	if (!target)
 		target = this->window;
 
-	// Ãâ·ÂÇÏ·Á´Â Ã¢ À§¿¡ ¿©·¯ ÅØ½ºÃÄ µîÀ» È­¸é¿¡ ±×¸²
-	// ÇöÀç´Â ÀÓ½Ã ÅØ½ºÆ®¸¦ È­¸é¿¡ ±×·ÁÁÜ
+	// ì¶œë ¥í•˜ë ¤ëŠ” ì°½ ìœ„ì— ì—¬ëŸ¬ í…ìŠ¤ì³ ë“±ì„ í™”ë©´ì— ê·¸ë¦¼
+	// í˜„ìž¬ëŠ” ìž„ì‹œ í…ìŠ¤íŠ¸ë¥¼ í™”ë©´ì— ê·¸ë ¤ì¤Œ
 	target->draw(*this->text);
 }

--- a/src/State.h
+++ b/src/State.h
@@ -4,8 +4,6 @@
 class State
 {
 private:
-	sf::Font* font;
-	sf::Text* text;
 
 protected:
 	sf::RenderWindow* window;

--- a/src/State.h
+++ b/src/State.h
@@ -16,6 +16,7 @@ public:
 	virtual ~State();
 
 	const bool& GetQuit() const;
+	virtual void CheckForQuit();
 	
 	// 순수 가상 함수 처리
 	// 모든 State들이 필수적으로 override해야 함

--- a/src/State.h
+++ b/src/State.h
@@ -17,9 +17,11 @@ public:
 
 	const bool& GetQuit() const;
 	
-	void EndState();
-	void UpdateInput(const float& dt);
-	void Update(const float& dt);
-	void Render(sf::RenderTarget* target);
+	// 순수 가상 함수 처리
+	// 모든 State들이 필수적으로 override해야 함
+	virtual void EndState() = 0;
+	virtual void UpdateInput(const float& dt) = 0;
+	virtual void Update(const float& dt) = 0;
+	virtual void Render(sf::RenderTarget* target) = 0;
 };
 

--- a/src/TitleState.cpp
+++ b/src/TitleState.cpp
@@ -16,10 +16,20 @@ TitleState::~TitleState()
 void TitleState::InitTexts()
 {
     title_text.setFont(*(this->font));
-    title_text.setCharacterSize(72);
+    title_text.setCharacterSize(88);
     title_text.setFillColor(sf::Color::White);
     title_text.setString("Brick Pong");
-    title_text.setPosition(CustomMath::GetCenterPos(CustomMath::CENTER, 200, title_text.getLocalBounds().width));
+    title_text.setPosition(CustomMath::GetCenterPos(CustomMath::CENTER, 150, title_text.getLocalBounds().width));
+
+    std::string menu_str[] = {"Game Start", "Setting", "Exit Game"};
+    for (int i = 0; i < 3; ++i)
+    {
+        menu_text[i].setFont(*(this->font));
+        menu_text[i].setCharacterSize(48);
+        menu_text[i].setFillColor(sf::Color::White);
+        menu_text[i].setString(menu_str[i]);
+        menu_text[i].setPosition(CustomMath::GetCenterPos(CustomMath::CENTER, 360 + 70 * i, menu_text[i].getLocalBounds().width));
+    }
 }
 
 void TitleState::EndState() 
@@ -44,4 +54,7 @@ void TitleState::Render(sf::RenderTarget* target)
 
     // 텍스트 렌더링
     target->draw(title_text);
+
+    for (int i = 0; i < 3; ++i)
+        target->draw(menu_text[i]);
 }

--- a/src/TitleState.cpp
+++ b/src/TitleState.cpp
@@ -1,27 +1,33 @@
 #include "TitleState.h"
 
-TitleState::TitleState(sf::RenderWindow* window) : State(window) {
+TitleState::TitleState(sf::RenderWindow* window) : State(window) 
+{
     this->font = new sf::Font();
     this->font->loadFromFile("./Resources/Arial.ttf");
 }
 
-TitleState::~TitleState() {
+TitleState::~TitleState() 
+{
     delete this->font;
 }
 
-void TitleState::EndState() {
+void TitleState::EndState() 
+{
 
 }
 
-void TitleState::UpdateInput(const float& dt) {
+void TitleState::UpdateInput(const float& dt) 
+{
     this->CheckForQuit();
 }
 
-void TitleState::Update(const float& dt) {
+void TitleState::Update(const float& dt) 
+{
 
 }
 
-void TitleState::Render(sf::RenderTarget* target) {
+void TitleState::Render(sf::RenderTarget* target) 
+{
     if (!target)
         target = this->window;
 }

--- a/src/TitleState.cpp
+++ b/src/TitleState.cpp
@@ -4,11 +4,23 @@ TitleState::TitleState(sf::RenderWindow* window) : State(window)
 {
     this->font = new sf::Font();
     this->font->loadFromFile("./resources/font/Arial.ttf");
+
+    this->InitTexts();
 }
 
 TitleState::~TitleState() 
 {
     delete this->font;
+}
+
+void TitleState::InitTexts()
+{
+    title_text.setFont(*(this->font));
+    title_text.setCharacterSize(24);
+    title_text.setFillColor(sf::Color::White);
+    title_text.setPosition(sf::Vector2f(400., 200.));
+    title_text.setString("Brick Pong");
+    std::cout << "??";
 }
 
 void TitleState::EndState() 
@@ -30,4 +42,7 @@ void TitleState::Render(sf::RenderTarget* target)
 {
     if (!target)
         target = this->window;
+
+    // 텍스트 렌더링
+    target->draw(title_text);
 }

--- a/src/TitleState.cpp
+++ b/src/TitleState.cpp
@@ -14,7 +14,7 @@ void TitleState::EndState() {
 }
 
 void TitleState::UpdateInput(const float& dt) {
-
+    this->CheckForQuit();
 }
 
 void TitleState::Update(const float& dt) {
@@ -22,5 +22,6 @@ void TitleState::Update(const float& dt) {
 }
 
 void TitleState::Render(sf::RenderTarget* target) {
-
+    if (!target)
+        target = this->window;
 }

--- a/src/TitleState.cpp
+++ b/src/TitleState.cpp
@@ -1,0 +1,26 @@
+#include "TitleState.h"
+
+TitleState::TitleState(sf::RenderWindow* window) : State(window) {
+    this->font = new sf::Font();
+    this->font->loadFromFile("./Resources/Arial.ttf");
+}
+
+TitleState::~TitleState() {
+    delete this->font;
+}
+
+void TitleState::EndState() {
+
+}
+
+void TitleState::UpdateInput(const float& dt) {
+
+}
+
+void TitleState::Update(const float& dt) {
+
+}
+
+void TitleState::Render(sf::RenderTarget* target) {
+
+}

--- a/src/TitleState.cpp
+++ b/src/TitleState.cpp
@@ -3,7 +3,7 @@
 TitleState::TitleState(sf::RenderWindow* window) : State(window) 
 {
     this->font = new sf::Font();
-    this->font->loadFromFile("./Resources/Arial.ttf");
+    this->font->loadFromFile("./resources/font/Arial.ttf");
 }
 
 TitleState::~TitleState() 

--- a/src/TitleState.cpp
+++ b/src/TitleState.cpp
@@ -2,25 +2,31 @@
 
 TitleState::TitleState(sf::RenderWindow* window) : State(window) 
 {
+    // 폰트 파일에서 가져와서 로드
     this->font = new sf::Font();
     this->font->loadFromFile("./resources/font/Arial.ttf");
 
+    // 타이틀 화면 텍스트들 초기화
     this->InitTexts();
 }
 
 TitleState::~TitleState() 
 {
+    // 폰트 메모리 할당 해제
     delete this->font;
 }
 
 void TitleState::InitTexts()
 {
+    // 게임 제목 텍스트 설정
+    // 순서대로 폰트, 글자 크기, 색상, 메시지, 위치
     title_text.setFont(*(this->font));
     title_text.setCharacterSize(88);
     title_text.setFillColor(sf::Color::White);
     title_text.setString("Brick Pong");
     title_text.setPosition(CustomMath::GetCenterPos(CustomMath::CENTER, 150, title_text.getLocalBounds().width));
 
+    // 메뉴 텍스트 설정
     std::string menu_str[] = {"Game Start", "Setting", "Exit Game"};
     for (int i = 0; i < 3; ++i)
     {

--- a/src/TitleState.cpp
+++ b/src/TitleState.cpp
@@ -16,11 +16,10 @@ TitleState::~TitleState()
 void TitleState::InitTexts()
 {
     title_text.setFont(*(this->font));
-    title_text.setCharacterSize(24);
+    title_text.setCharacterSize(72);
     title_text.setFillColor(sf::Color::White);
-    title_text.setPosition(sf::Vector2f(400., 200.));
     title_text.setString("Brick Pong");
-    std::cout << "??";
+    title_text.setPosition(CustomMath::GetCenterPos(CustomMath::CENTER, 200, title_text.getLocalBounds().width));
 }
 
 void TitleState::EndState() 

--- a/src/TitleState.h
+++ b/src/TitleState.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "State.h"
 
-class TitleState : State
+class TitleState : public State
 {
 private:
 

--- a/src/TitleState.h
+++ b/src/TitleState.h
@@ -7,12 +7,16 @@ private:
 
 public:
 	sf::Font* font;
+	sf::Text title_text;
+	sf::Text menu_text[3];
 	// 일단 필요하지 않을 것 같아 주석 처리
 	// sf::Texture bgTexture;
 	// sf::Sprite bgSprite;
 
 	TitleState(sf::RenderWindow* window);
 	virtual ~TitleState();
+
+	void InitTexts();
 
 	void EndState();
 	void UpdateInput(const float& dt);

--- a/src/TitleState.h
+++ b/src/TitleState.h
@@ -7,15 +7,16 @@ private:
 
 public:
 	sf::Font* font;
-	sf::Texture bgTexture;
-	sf::Sprite bgSprite;
+	// 일단 필요하지 않을 것 같아 주석 처리
+	// sf::Texture bgTexture;
+	// sf::Sprite bgSprite;
 
 	TitleState(sf::RenderWindow* window);
 	virtual ~TitleState();
 
-	void endState();
-	void updateInput(const float& dt);
-	void update(const float& dt);
-	void render(sf::RenderTarget* target);
+	void EndState();
+	void UpdateInput(const float& dt);
+	void Update(const float& dt);
+	void Render(sf::RenderTarget* target);
 };
 

--- a/src/TitleState.h
+++ b/src/TitleState.h
@@ -1,0 +1,21 @@
+#pragma once
+#include "State.h"
+
+class TitleState : State
+{
+private:
+
+public:
+	sf::Font* font;
+	sf::Texture bgTexture;
+	sf::Sprite bgSprite;
+
+	TitleState(sf::RenderWindow* window);
+	virtual ~TitleState();
+
+	void endState();
+	void updateInput(const float& dt);
+	void update(const float& dt);
+	void render(sf::RenderTarget* target);
+};
+

--- a/src/header/stdafx.h
+++ b/src/header/stdafx.h
@@ -19,4 +19,6 @@
 #include <SFML/Graphics.hpp>
 #include <SFML/System.hpp>
 
+#include "CustomFunction.h"
+
 #pragma warning(disable:4996)


### PR DESCRIPTION
## 김지훈 1차 작업 상황
- 타이틀 화면을 만들었습니다. 제목, 3개의 메뉴 텍스트가 표출되도록 만들었습니다.
    - 메뉴 클릭 시 화면 전환은 차후 추가할 예정입니다.
 
- 인게임에서 필요한 다른 장면들(MapSelectState, InGameState, ResultState) 등의 기본 클래스 틀을 제작했습니다. 해당 클래스들은 모두 State 클래스를 상속받았으며, GameManager에 있는 장면 덱(deque)에서 (upcasting된 채로) 관리됩니다.

<br />
작업 내용 및 코드 확인 부탁드립니다.

![Code_NlE9QKlPJq](https://github.com/AppliedAlpha/Brick-Pong/assets/36326864/7b845c8e-cf10-4665-b280-3de6722d42ed)
