### PR TITLE
게임 스테이지 개발용 InGameState 선작업

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) [year] [fullname]
+Copyright (c) 2024 OSS Team 3 "Brick Pong"
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/OSS-2024-Game.vcxproj
+++ b/OSS-2024-Game.vcxproj
@@ -141,6 +141,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="src\Ball.cpp" />
     <ClCompile Include="src\CustomFunction.cpp" />
     <ClCompile Include="src\Brick.cpp" />
     <ClCompile Include="src\GameManager.cpp" />
@@ -154,6 +155,7 @@
     <ClCompile Include="src\Transform.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="src\Ball.h" />
     <ClInclude Include="src\CustomFunction.h" />
     <ClInclude Include="src\Brick.h" />
     <ClInclude Include="src\GameObject.h" />
@@ -164,7 +166,7 @@
     <ClInclude Include="src\ResultState.h" />
     <ClInclude Include="src\Player.h" />
     <ClInclude Include="src\State.h" />
-	<ClInclude Include="src\Transform.h" />
+    <ClInclude Include="src\Transform.h" />
     <ClInclude Include="src\TitleState.h" />
   </ItemGroup>
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-# OSS-2024-Game
+# (2024-01) 오픈소스SW개론 : Brick Pong
+
+## Brick Pong
+
+## License
+Copyright (c) 2024 OSS Team 3 "Brick Pong" All rights reserved.
+
+이 프로그램은 [MIT 라이선스](LICENSE.txt)에 기반을 두고 있습니다.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,26 @@
 
 ## Brick Pong
 
+## Contributor & Collaborators
+### Jihun Kim (PM)
+- [**@AppliedAlpha**](https://github.com/AppliedAlpha)   
+- <appliedalpha@naver.com> / <jihoon70762@gmail.com>
+
+### O Jae O
+- [**@OruteZ**](https://github.com/OruteZ)
+
+### Hyeongjun Kim
+- [**@Kimhyeog**](https://github.com/Kimhyeog)
+
+### Changin Lim
+- [**@cba700**](https://github.com/cba700)
+
 ## License
 Copyright (c) 2024 OSS Team 3 "Brick Pong" All rights reserved.
 
 이 프로그램은 [MIT 라이선스](LICENSE.txt)에 기반을 두고 있습니다.
+
+## External Libraries & Special Thanks
+- [SFML (Simple and Fast Multimedia Library)](https://github.com/SFML/SFML)
+    - C++ Windowing, Graphic 등을 지원하는 멀티미디어 API
+    - [zlib/libpng license](https://github.com/SFML/SFML/blob/master/license.md) 라이선스 기반 (제한 없이 사용 가능)

--- a/src/GameManager.cpp
+++ b/src/GameManager.cpp
@@ -38,7 +38,8 @@ void GameManager::InitWindow()
 void GameManager::InitStates()
 {
 	// State 덱에 새로운 State를 넣어줌
-	this->states.push_front(new TitleState(this->window));
+	// TODO: InGameState 테스트 종료 시 TitleState로 변경
+	this->states.push_front(new InGameState(this->window));
 }
 
 // 프레임마다 흐른 시각(dt, deltaTime)을 업데이트해줌

--- a/src/GameManager.h
+++ b/src/GameManager.h
@@ -2,6 +2,7 @@
 #include "header/stdafx.h"
 #include "State.h"
 #include "TitleState.h"
+#include "InGameState.h"
 
 class GameManager 
 {

--- a/src/InGameState.cpp
+++ b/src/InGameState.cpp
@@ -4,11 +4,15 @@ InGameState::InGameState(sf::RenderWindow* window) : State(window)
 {
     this->font = new sf::Font();
     this->font->loadFromFile("./resources/font/Arial.ttf");
+
+    // 공 초기화
+    this->ball = new Ball(20.f, 5.f, 1280, 720);
 }
 
 InGameState::~InGameState() 
 {
     delete this->font;
+    delete this->ball;
 }
 
 void InGameState::EndState() 
@@ -23,10 +27,18 @@ void InGameState::UpdateInput(const float& dt)
 
 void InGameState::Update(const float& dt) 
 {
-
+    // 공 움직임 처리
+    this->ball->move();
 }
 
 void InGameState::Render(sf::RenderTarget* target) 
 {
+    // 출력 대상 미지정 시 현재 화면으로 설정
+    if (!target)
+        target = this->window;
 
+    // target->draw(대상); 으로 렌더링하길 권장합니다.
+
+    // 화면에 공 그리기
+    target->draw(this->ball->getShape());
 }

--- a/src/InGameState.h
+++ b/src/InGameState.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "State.h"
+#include "Ball.h"
 
 class InGameState : public State
 {
@@ -10,6 +11,8 @@ public:
 	// 일단 필요하지 않을 것 같아 주석 처리
 	// sf::Texture bgTexture;
 	// sf::Sprite bgSprite;
+
+	Ball* ball;
 
 	InGameState(sf::RenderWindow* window);
 	virtual ~InGameState();

--- a/src/TitleState.cpp
+++ b/src/TitleState.cpp
@@ -55,6 +55,7 @@ void TitleState::Update(const float& dt)
 
 void TitleState::Render(sf::RenderTarget* target) 
 {
+    // 출력 대상 미지정 시 현재 화면으로 설정
     if (!target)
         target = this->window;
 


### PR DESCRIPTION
- 게임 내부 스테이지를 개발하기 위해서, 프로그램 실행 시 GameManager가 맨 처음으로 만드는 State를 InGameState로 (테스트 겸) 변경해두었습니다.
- 기본 공을 추가해두었습니다. 테스트용이니 작업하실 땐 수정하셔도 좋습니다.
- 테스트가 끝나고 장면 전환을 만들고 나면, 코드를 합친 후 다시 원래대로 타이틀 화면(TitleState)을 띄우게 할 예정입니다.
- 게임 스테이지 개발이 필요하신 분들은 InGameState와, 기타 오브젝트 클래스들을 가지고 작업해주시면 되겠습니다.

+) README도 살짝 내용을 추가했습니다. (Repository 내에 있던 readme branch는 현재 branch에 반영 & 병합 후 삭제했습니다.)

![image](https://github.com/AppliedAlpha/Brick-Pong/assets/36326864/56d37918-3e70-4ffb-a696-3b1acba8c406)
