### PR TITLE
장면 전환 작업

### DIFF
--- a/src/GameManager.cpp
+++ b/src/GameManager.cpp
@@ -82,7 +82,7 @@ void GameManager::Update()
 			// 종료된 State가 InGameState라면
 			if (InGameState* inGameState = dynamic_cast<InGameState *>(this->states.front()))
 			{
-				// 종료 코드에서 받아온 승자를 ResultState로 넘김
+				// 종료 코드에서 받아온 승자를 ResultState로 넘김 
 				this->states.push_back(new ResultState(this->window, res));
 			}
 

--- a/src/GameManager.cpp
+++ b/src/GameManager.cpp
@@ -77,7 +77,7 @@ void GameManager::Update()
 		if (this->states.front()->GetQuit())
 		{
 			// 해당 State 종료를 위한 전처리 작업을 해줌
-			this->states.front()->EndState();
+			int res = this->states.front()->EndState();
 
 			// 해당 State의 포인터를 해제하고, 덱에서 제외시킴
 			delete this->states.front();

--- a/src/GameManager.cpp
+++ b/src/GameManager.cpp
@@ -79,6 +79,13 @@ void GameManager::Update()
 			// 해당 State 종료를 위한 전처리 작업을 해줌
 			int res = this->states.front()->EndState();
 
+			// 종료된 State가 InGameState라면
+			if (InGameState* inGameState = dynamic_cast<InGameState *>(this->states.front()))
+			{
+				// 종료 코드에서 받아온 승자를 ResultState로 넘김
+				this->states.push_back(new ResultState(this->window, res));
+			}
+
 			// 해당 State의 포인터를 해제하고, 덱에서 제외시킴
 			delete this->states.front();
 			this->states.pop_front();

--- a/src/GameManager.h
+++ b/src/GameManager.h
@@ -3,6 +3,7 @@
 #include "State.h"
 #include "TitleState.h"
 #include "InGameState.h"
+#include "ResultState.h"
 
 class GameManager 
 {

--- a/src/InGameState.cpp
+++ b/src/InGameState.cpp
@@ -27,7 +27,7 @@ InGameState::~InGameState()
 
 int InGameState::EndState() 
 {
-
+    return this->winner_num;
 }
 
 void InGameState::UpdateInput(const float& dt) 
@@ -77,11 +77,11 @@ void InGameState::CheckForQuit()
     State::CheckForQuit();
 
     //���� ���� �޼� �� ���� ����
-    int winner_num;
+    int winner;
 
-    if (scrSystem->IsGameFinished(winner_num))
+    if (scrSystem->IsGameFinished(winner))
     {
+        this->winner_num = winner;
         this->quit = true;
-        std::cout << winner_num;
     }
 }

--- a/src/InGameState.cpp
+++ b/src/InGameState.cpp
@@ -5,13 +5,13 @@ InGameState::InGameState(sf::RenderWindow* window) : State(window)
     this->font = new sf::Font();
     this->font->loadFromFile("./resources/font/Arial.ttf");
 
-    //Score System ÃÊ±âÈ­
+    //Score System ï¿½Ê±ï¿½È­
     this->scrSystem = new ScoreSystem();
 
-    // °ø ÃÊ±âÈ­
+    // ï¿½ï¿½ ï¿½Ê±ï¿½È­
     this->ball = new Ball(20.f, 5.f, 1280, 720, scrSystem);
 
-	// GameObjects ÃÊ±âÈ­
+	// GameObjects ï¿½Ê±ï¿½È­
 
 	this->player1 = new Player();
 
@@ -25,7 +25,7 @@ InGameState::~InGameState()
     delete this->scrSystem;
 }
 
-void InGameState::EndState() 
+int InGameState::EndState() 
 {
 
 }
@@ -39,14 +39,14 @@ void InGameState::Update(const float& dt)
 {
     this->CheckForQuit();
 
-    // °ø ¿òÁ÷ÀÓ Ã³¸®
+    // ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ Ã³ï¿½ï¿½
     this->ball->move();
     this->ball->checkCollisionWithWall();
 
-    // ÇÃ·¹ÀÌ¾î
+    // ï¿½Ã·ï¿½ï¿½Ì¾ï¿½
 	player1->Update(dt);
 
-	// °øÀÇ global bounds¿Í playerÀÇ Ãæµ¹ È®ÀÎ
+	// ï¿½ï¿½ï¿½ï¿½ global boundsï¿½ï¿½ playerï¿½ï¿½ ï¿½æµ¹ È®ï¿½ï¿½
 	if (this->ball->getShape().getGlobalBounds().intersects(this->player1->GetDrawable()->getGlobalBounds()))
 	{
 		this->player1->OnCollision(ball);
@@ -59,13 +59,13 @@ void InGameState::Update(const float& dt)
 
 void InGameState::Render(sf::RenderTarget* target) 
 {
-    // Ãâ·Â ´ë»ó ¹ÌÁöÁ¤ ½Ã ÇöÀç È­¸éÀ¸·Î ¼³Á¤
+    // ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ È­ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½
     if (!target)
         target = this->window;
 
-    // target->draw(´ë»ó); À¸·Î ·»´õ¸µÇÏ±æ ±ÇÀåÇÕ´Ï´Ù.
+    // target->draw(ï¿½ï¿½ï¿½); ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ï±ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½Õ´Ï´ï¿½.
 
-    // È­¸é¿¡ °ø ±×¸®±â
+    // È­ï¿½é¿¡ ï¿½ï¿½ ï¿½×¸ï¿½ï¿½ï¿½
     target->draw(this->ball->getShape());
 
     target->draw(*this->player1->GetDrawable());
@@ -76,7 +76,7 @@ void InGameState::CheckForQuit()
     //base class
     State::CheckForQuit();
 
-    //µæÁ¡ Á¶°Ç ´Þ¼º ½Ã °ÔÀÓ Á¾·á
+    //ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½Þ¼ï¿½ ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½
     int winner_num;
 
     if (scrSystem->IsGameFinished(winner_num))

--- a/src/InGameState.cpp
+++ b/src/InGameState.cpp
@@ -21,6 +21,8 @@ InGameState::~InGameState()
 {
     delete this->font;
     delete this->ball;
+
+    delete this->scrSystem;
 }
 
 void InGameState::EndState() 
@@ -35,6 +37,8 @@ void InGameState::UpdateInput(const float& dt)
 
 void InGameState::Update(const float& dt) 
 {
+    this->CheckForQuit();
+
     // 공 움직임 처리
     this->ball->move();
     this->ball->checkCollisionWithWall();
@@ -74,8 +78,10 @@ void InGameState::CheckForQuit()
 
     //득점 조건 달성 시 게임 종료
     int winner_num;
-    if(scrSystem->IsGameFinished(winner_num))
+
+    if (scrSystem->IsGameFinished(winner_num))
     {
         this->quit = true;
+        std::cout << winner_num;
     }
 }

--- a/src/InGameState.h
+++ b/src/InGameState.h
@@ -25,7 +25,7 @@ public:
 
 	virtual void CheckForQuit();
 
-	void EndState();
+	int EndState();
 	void UpdateInput(const float& dt);
 	void Update(const float& dt);
 	void Render(sf::RenderTarget* target);

--- a/src/InGameState.h
+++ b/src/InGameState.h
@@ -20,6 +20,8 @@ public:
 	Player* player1;
 	Player* player2;
 
+	int winner_num = -1;
+
 	InGameState(sf::RenderWindow* window);
 	virtual ~InGameState();
 

--- a/src/MapSelectState.cpp
+++ b/src/MapSelectState.cpp
@@ -13,7 +13,7 @@ MapSelectState::~MapSelectState()
 
 int MapSelectState::EndState() 
 {
-
+    return 0;
 }
 
 void MapSelectState::UpdateInput(const float& dt) 

--- a/src/MapSelectState.cpp
+++ b/src/MapSelectState.cpp
@@ -11,7 +11,7 @@ MapSelectState::~MapSelectState()
     delete this->font;
 }
 
-void MapSelectState::EndState() 
+int MapSelectState::EndState() 
 {
 
 }

--- a/src/MapSelectState.h
+++ b/src/MapSelectState.h
@@ -14,7 +14,7 @@ public:
 	MapSelectState(sf::RenderWindow* window);
 	virtual ~MapSelectState();
 
-	void EndState();
+	int EndState();
 	void UpdateInput(const float& dt);
 	void Update(const float& dt);
 	void Render(sf::RenderTarget* target);

--- a/src/ResultState.cpp
+++ b/src/ResultState.cpp
@@ -32,7 +32,7 @@ void ResultState::InitTexts()
     }
 }
 
-void ResultState::EndState() 
+int ResultState::EndState() 
 {
 
 }

--- a/src/ResultState.cpp
+++ b/src/ResultState.cpp
@@ -18,7 +18,7 @@ void ResultState::InitTexts()
     result_text.setFont(*(this->font));
     result_text.setCharacterSize(88);
     result_text.setFillColor(sf::Color::White);
-    result_text.setString("Player X Wins");
+    result_text.setString("Player " + std::to_string(this->winner_num) + "Wins");
     result_text.setPosition(CustomMath::GetCenterPos(CustomMath::CENTER, 150, result_text.getLocalBounds().width));
 
     std::string menu_str[] = {"Retry", "Back to Menu"};
@@ -34,7 +34,6 @@ void ResultState::InitTexts()
 
 int ResultState::EndState() 
 {
-
 }
 
 void ResultState::UpdateInput(const float& dt) 

--- a/src/ResultState.cpp
+++ b/src/ResultState.cpp
@@ -1,14 +1,35 @@
 #include "ResultState.h"
 
-ResultState::ResultState(sf::RenderWindow* window) : State(window) 
+ResultState::ResultState(sf::RenderWindow* window, int winner) : winner_num(winner), State(window) 
 {
     this->font = new sf::Font();
     this->font->loadFromFile("./resources/font/Arial.ttf");
+
+    this->InitTexts();
 }
 
 ResultState::~ResultState() 
 {
     delete this->font;
+}
+
+void ResultState::InitTexts() 
+{
+    result_text.setFont(*(this->font));
+    result_text.setCharacterSize(88);
+    result_text.setFillColor(sf::Color::White);
+    result_text.setString("Player X Wins");
+    result_text.setPosition(CustomMath::GetCenterPos(CustomMath::CENTER, 150, result_text.getLocalBounds().width));
+
+    std::string menu_str[] = {"Retry", "Back to Menu"};
+    for (int i = 0; i < 2; ++i)
+    {
+        menu_text[i].setFont(*(this->font));
+        menu_text[i].setCharacterSize(48);
+        menu_text[i].setFillColor(sf::Color::White);
+        menu_text[i].setString(menu_str[i]);
+        menu_text[i].setPosition(CustomMath::GetCenterPos(CustomMath::CENTER, 360 + 90 * i, menu_text[i].getLocalBounds().width));
+    }
 }
 
 void ResultState::EndState() 
@@ -23,10 +44,16 @@ void ResultState::UpdateInput(const float& dt)
 
 void ResultState::Update(const float& dt) 
 {
-
+    this->CheckForQuit();
 }
 
 void ResultState::Render(sf::RenderTarget* target) 
 {
+    if (!target)
+        target = this->window;
 
+    target->draw(result_text);
+
+    for (int i = 0; i < 2; ++i)
+        target->draw(menu_text[i]);
 }

--- a/src/ResultState.cpp
+++ b/src/ResultState.cpp
@@ -18,7 +18,7 @@ void ResultState::InitTexts()
     result_text.setFont(*(this->font));
     result_text.setCharacterSize(88);
     result_text.setFillColor(sf::Color::White);
-    result_text.setString("Player " + std::to_string(this->winner_num) + "Wins");
+    result_text.setString("Player " + std::to_string(this->winner_num) + " Wins");
     result_text.setPosition(CustomMath::GetCenterPos(CustomMath::CENTER, 150, result_text.getLocalBounds().width));
 
     std::string menu_str[] = {"Retry", "Back to Menu"};

--- a/src/ResultState.cpp
+++ b/src/ResultState.cpp
@@ -34,6 +34,7 @@ void ResultState::InitTexts()
 
 int ResultState::EndState() 
 {
+    return 0;
 }
 
 void ResultState::UpdateInput(const float& dt) 

--- a/src/ResultState.h
+++ b/src/ResultState.h
@@ -11,8 +11,14 @@ public:
 	// sf::Texture bgTexture;
 	// sf::Sprite bgSprite;
 
-	ResultState(sf::RenderWindow* window);
+	sf::Text result_text;
+	sf::Text menu_text[2];
+	int winner_num;
+
+	ResultState(sf::RenderWindow* window, int winner);
 	virtual ~ResultState();
+
+	void InitTexts();
 
 	void EndState();
 	void UpdateInput(const float& dt);

--- a/src/ResultState.h
+++ b/src/ResultState.h
@@ -20,7 +20,7 @@ public:
 
 	void InitTexts();
 
-	void EndState();
+	int EndState();
 	void UpdateInput(const float& dt);
 	void Update(const float& dt);
 	void Render(sf::RenderTarget* target);

--- a/src/ScoreSystem.cpp
+++ b/src/ScoreSystem.cpp
@@ -35,10 +35,7 @@ int ScoreSystem::GetScore(int player_number)
 
 // 게임이 끝났는지 확인하는 메서드
 bool ScoreSystem::CheckGameFinish() {
-	if (scores.first >= winning_score) return true;
-	if (scores.second >= winning_score) return true;
-
-	return false;
+	return std::max(scores.first, scores.second) >= winning_score;
 }
 
 void ScoreSystem::AddScore(int player_number, int score)

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -29,7 +29,7 @@ void State::CheckForQuit() {
 }
 
 // State 종료 요청을 받았을 시 종료 전 작업을 하는 함수
-void State::EndState()
+int State::EndState()
 {
 
 }

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -43,6 +43,9 @@ void State::UpdateInput(const float& dt)
 // State의 정보를 프레임 단위로 갱신하는 함수
 void State::Update(const float& dt)
 {
+	// 업데이트마다 현재 State를 종료해야 하는 지 체크 
+	this->CheckForQuit();
+
 	// 일단 프레임마다 입력 확인만 해줌
 	this->UpdateInput(dt);
 

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -31,7 +31,7 @@ void State::CheckForQuit() {
 // State 종료 요청을 받았을 시 종료 전 작업을 하는 함수
 int State::EndState()
 {
-
+	return 0;
 }
 
 // 입력을 받아 처리하는 함수

--- a/src/State.h
+++ b/src/State.h
@@ -18,7 +18,7 @@ public:
 	
 	// 순수 가상 함수 처리
 	// 모든 State들이 필수적으로 override해야 함
-	virtual void EndState() = 0;
+	virtual int EndState() = 0;
 	virtual void UpdateInput(const float& dt) = 0;
 	virtual void Update(const float& dt) = 0;
 	virtual void Render(sf::RenderTarget* target) = 0;

--- a/src/TitleState.cpp
+++ b/src/TitleState.cpp
@@ -45,12 +45,12 @@ void TitleState::EndState()
 
 void TitleState::UpdateInput(const float& dt) 
 {
-    this->CheckForQuit();
+    
 }
 
 void TitleState::Update(const float& dt) 
 {
-
+    this->CheckForQuit();
 }
 
 void TitleState::Render(sf::RenderTarget* target) 

--- a/src/TitleState.cpp
+++ b/src/TitleState.cpp
@@ -40,7 +40,7 @@ void TitleState::InitTexts()
 
 int TitleState::EndState() 
 {
-
+    return 0;
 }
 
 void TitleState::UpdateInput(const float& dt) 

--- a/src/TitleState.cpp
+++ b/src/TitleState.cpp
@@ -38,7 +38,7 @@ void TitleState::InitTexts()
     }
 }
 
-void TitleState::EndState() 
+int TitleState::EndState() 
 {
 
 }

--- a/src/TitleState.h
+++ b/src/TitleState.h
@@ -18,7 +18,7 @@ public:
 
 	void InitTexts();
 
-	void EndState();
+	int EndState();
 	void UpdateInput(const float& dt);
 	void Update(const float& dt);
 	void Render(sf::RenderTarget* target);


### PR DESCRIPTION
- InGameState 종료 시 승리자 번호를 ResultState에 넘겨주어 전환하는 방식으로 구성 완료
- State 내부 함수 EndState를 void -> int로 변경. (종료 코드 받아올 수 있도록 함.)
- 일부 코드 미세하게 변경

![image](https://github.com/AppliedAlpha/Brick-Pong/assets/36326864/45b47fe3-9311-44d4-b8e8-20209ec53546)
